### PR TITLE
Feat: singular position for labels, removed irrel regions, improved legibility

### DIFF
--- a/src/app/features/MainMap/config.tsx
+++ b/src/app/features/MainMap/config.tsx
@@ -21,6 +21,7 @@ import {
     spiderfyClusters,
 } from '@/app/features/MainMap/utils';
 import { basemaps } from '@/app/components/Map/consts';
+import { huc02Centers } from '@/data/huc02Centers';
 
 export const MAP_ID = 'main';
 
@@ -32,6 +33,7 @@ export enum SourceId {
     HUC2Boundaries = 'hu02',
     AssociatedData = 'associated-data-source',
     Spiderify = 'spiderify',
+    HUC2GeoJSON = 'huc-02-geojson',
 }
 
 export enum LayerId {
@@ -64,13 +66,24 @@ export const MAINSTEM_DRAINAGE_MEDIUM = 1600;
 export const MAINSTEM_SMALL_LINE_WIDTH = 3;
 export const MAINSTEM_MEDIUM_LINE_WIDTH = 4;
 export const MAINSTEM_LARGE_LINE_WIDTH = 6;
+export const MAINSTEM_VISIBLE_ZOOM = 5;
+export const MAINSTEM_OPACITY_ZOOM = 6;
 
 export const MAINSTEM_OPACITY_EXPRESSION: ExpressionSpecification = [
     'step',
     ['zoom'],
     0.3,
-    6,
+    MAINSTEM_OPACITY_ZOOM,
     0.8,
+];
+
+const filteredHucs = ['19', '20', '21', '22'];
+const hucFilterExpression: ExpressionSpecification = [
+    'match',
+    ['get', 'HUC2'],
+    filteredHucs,
+    false,
+    true,
 ];
 
 /**********************************************************************
@@ -127,6 +140,15 @@ export const sourceConfigs: SourceConfig[] = [
                 type: 'FeatureCollection',
                 features: [],
             },
+            cluster: false,
+        },
+    },
+    {
+        id: SourceId.HUC2GeoJSON,
+        type: Sources.GeoJSON,
+        definition: {
+            type: 'geojson',
+            data: huc02Centers,
             cluster: false,
         },
     },
@@ -338,24 +360,24 @@ export const getLayerConfig = (
                     'line-color': getLayerColor(LayerId.HUC2Boundaries),
                     'line-width': 3,
                 },
+                filter: hucFilterExpression,
             };
         case SubLayerId.HUC2BoundaryLabels:
             return {
                 id: SubLayerId.HUC2BoundaryLabels,
                 type: LayerType.Symbol,
-                source: SourceId.HUC2Boundaries,
-                'source-layer': SourceId.HUC2Boundaries,
+                source: SourceId.HUC2GeoJSON,
                 layout: {
-                    'text-field': ['get', 'NAME'],
+                    'text-field': ['get', 'name'],
                     'text-variable-anchor': ['top', 'bottom', 'left', 'right'],
-                    'text-radial-offset': 0.25,
-
                     'text-size': 18,
-                    'text-justify': 'auto',
                 },
                 paint: {
                     'text-color': getLayerColor(LayerId.HUC2Boundaries),
                     'text-opacity': 0,
+                    'text-halo-blur': 1,
+                    'text-halo-color': '#000000',
+                    'text-halo-width': 2,
                 },
             };
         case SubLayerId.HUC2BoundaryFill:
@@ -368,6 +390,7 @@ export const getLayerConfig = (
                     'fill-color': '#000',
                     'fill-opacity': 0,
                 },
+                filter: hucFilterExpression,
             };
         case LayerId.AssociatedData:
             return null;
@@ -482,47 +505,56 @@ export const getLayerHoverFunction = (
             case SubLayerId.MainstemsSmall:
                 return (e) => {
                     if (!hoverOnCluster) {
-                        map.getCanvas().style.cursor = 'pointer';
+                        const zoom = map.getZoom();
+                        if (zoom > MAINSTEM_VISIBLE_ZOOM) {
+                            map.getCanvas().style.cursor = 'pointer';
 
-                        const feature = e.features?.[0];
-                        if (feature && feature.properties) {
-                            const html = `<strong style="color:black;">${feature.properties.name_at_outlet}</strong>`;
-                            hoverPopup
-                                .setLngLat(e.lngLat)
-                                .setHTML(html)
-                                .addTo(map);
+                            const feature = e.features?.[0];
+                            if (feature && feature.properties) {
+                                const html = `<strong style="color:black;">${feature.properties.name_at_outlet}</strong>`;
+                                hoverPopup
+                                    .setLngLat(e.lngLat)
+                                    .setHTML(html)
+                                    .addTo(map);
+                            }
                         }
                     }
                 };
             case SubLayerId.MainstemsMedium:
                 return (e) => {
                     if (!hoverOnCluster) {
-                        map.getCanvas().style.cursor = 'pointer';
+                        const zoom = map.getZoom();
+                        if (zoom > MAINSTEM_VISIBLE_ZOOM) {
+                            map.getCanvas().style.cursor = 'pointer';
 
-                        const feature = e.features?.[0];
-                        if (feature && feature.properties) {
-                            const html = `<strong style="color:black;">${feature.properties.name_at_outlet}</strong>`;
+                            const feature = e.features?.[0];
+                            if (feature && feature.properties) {
+                                const html = `<strong style="color:black;">${feature.properties.name_at_outlet}</strong>`;
 
-                            hoverPopup
-                                .setLngLat(e.lngLat)
-                                .setHTML(html)
-                                .addTo(map);
+                                hoverPopup
+                                    .setLngLat(e.lngLat)
+                                    .setHTML(html)
+                                    .addTo(map);
+                            }
                         }
                     }
                 };
             case SubLayerId.MainstemsLarge:
                 return (e) => {
                     if (!hoverOnCluster) {
-                        map.getCanvas().style.cursor = 'pointer';
+                        const zoom = map.getZoom();
+                        if (zoom > MAINSTEM_VISIBLE_ZOOM) {
+                            map.getCanvas().style.cursor = 'pointer';
 
-                        const feature = e.features?.[0];
-                        if (feature && feature.properties) {
-                            const html = `<strong style="color:black;">${feature.properties.name_at_outlet}</strong>`;
+                            const feature = e.features?.[0];
+                            if (feature && feature.properties) {
+                                const html = `<strong style="color:black;">${feature.properties.name_at_outlet}</strong>`;
 
-                            hoverPopup
-                                .setLngLat(e.lngLat)
-                                .setHTML(html)
-                                .addTo(map);
+                                hoverPopup
+                                    .setLngLat(e.lngLat)
+                                    .setHTML(html)
+                                    .addTo(map);
+                            }
                         }
                     }
                 };
@@ -573,18 +605,20 @@ export const getLayerHoverFunction = (
                 };
             case SubLayerId.HUC2BoundaryFill:
                 return (e) => {
-                    map.getCanvas().style.cursor = 'pointer';
-                    const feature = e.features?.[0] as
-                        | Feature<LineString>
-                        | undefined;
                     const zoom = map.getZoom();
-                    if (feature && feature.properties && zoom < 7) {
-                        const name = feature.properties.NAME;
-                        map.setPaintProperty(
-                            SubLayerId.HUC2BoundaryLabels,
-                            'text-opacity',
-                            ['case', ['==', ['get', 'NAME'], name], 1, 0]
-                        );
+                    if (zoom < MAINSTEM_VISIBLE_ZOOM) {
+                        map.getCanvas().style.cursor = 'pointer';
+                        const feature = e.features?.[0] as
+                            | Feature<LineString>
+                            | undefined;
+                        if (feature && feature.properties) {
+                            const id = Number(feature.properties.HUC2);
+                            map.setPaintProperty(
+                                SubLayerId.HUC2BoundaryLabels,
+                                'text-opacity',
+                                ['case', ['==', ['get', 'id'], id], 1, 0]
+                            );
+                        }
                     }
                 };
             default:
@@ -651,12 +685,16 @@ export const getLayerMouseMoveFunction = (
                         | Feature<LineString>
                         | undefined;
                     const zoom = map.getZoom();
-                    if (feature && feature.properties && zoom < 6) {
-                        const name = feature.properties.NAME;
+                    if (
+                        feature &&
+                        feature.properties &&
+                        zoom < MAINSTEM_VISIBLE_ZOOM
+                    ) {
+                        const id = Number(feature.properties.HUC2);
                         map.setPaintProperty(
                             SubLayerId.HUC2BoundaryLabels,
                             'text-opacity',
-                            ['case', ['==', ['get', 'NAME'], name], 1, 0]
+                            ['case', ['==', ['get', 'id'], id], 1, 0]
                         );
                     }
                 };
@@ -875,9 +913,6 @@ export const layerDefinitions: MainLayerDefinition[] = [
                 controllable: false,
                 legend: false,
                 config: getLayerConfig(SubLayerId.AssociatedDataUnclustered),
-                // hoverFunction: getLayerHoverFunction(
-                //     SubLayerId.AssociatedDataUnclustered
-                // ),
             },
         ],
     },
@@ -892,19 +927,4 @@ export const layerDefinitions: MainLayerDefinition[] = [
             LayerId.SpiderifyPoints
         ),
     },
-
-    // {
-    //     id: LayerId.Points,
-    //     controllable: true,
-    //     config: getLayerConfig(LayerId.Points),
-    //     hoverFunction: getLayerHoverFunction(LayerId.Points),
-    //     clickFunction: getLayerClickFunction(LayerId.Points),
-    //     subLayers: [
-    //         {
-    //             id: SubLayerId.PointsSmall,
-    //             controllable: true,
-    //             config: getLayerConfig(SubLayerId.PointsSmall),
-    //         },
-    //     ],
-    // },
 ];

--- a/src/app/features/MainMap/index.tsx
+++ b/src/app/features/MainMap/index.tsx
@@ -17,6 +17,7 @@ import {
     MAINSTEM_SMALL_LINE_WIDTH,
     MAINSTEM_MEDIUM_LINE_WIDTH,
     MAINSTEM_LARGE_LINE_WIDTH,
+    MAINSTEM_VISIBLE_ZOOM,
 } from '@/app/features/MainMap/config';
 import { useMap } from '@/app/contexts/MapContexts';
 import { useDispatch, useSelector } from 'react-redux';
@@ -72,7 +73,7 @@ export const MainMap: React.FC<Props> = (props) => {
         }
         const handleInitialZoom = () => {
             const zoom = map.getZoom();
-            if (zoom >= 5) {
+            if (zoom >= MAINSTEM_VISIBLE_ZOOM) {
                 dispatch(
                     setLayerVisibility({
                         [SubLayerId.MainstemsSmall]: true,

--- a/src/data/huc02Centers.ts
+++ b/src/data/huc02Centers.ts
@@ -154,7 +154,7 @@ export const huc02Centers: FeatureCollection<Geometry, GeoJsonProperties> = {
             },
             geometry: {
                 type: 'Point',
-                coordinates: [-105.85927750623031, 31.923558206414327],
+                coordinates: [-104.221449787, 30.865801709],
             },
         },
         {

--- a/src/data/huc02Centers.ts
+++ b/src/data/huc02Centers.ts
@@ -1,0 +1,260 @@
+import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
+
+export const huc02Centers: FeatureCollection<Geometry, GeoJsonProperties> = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            properties: {
+                id: 1,
+                name: 'New England Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-70.025842537, 44.432876329],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 2,
+                name: 'Mid Atlantic Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-76.64636500808136, 40.84141988456247],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 3,
+                name: 'South Atlantic-Gulf Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-84.00641573835105, 33.3596708184683],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 4,
+                name: 'Great Lakes Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-83.670986631, 45.274667402],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 5,
+                name: 'Ohio Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-83.858233346, 38.868693634],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 6,
+                name: 'Tennessee Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-85.180811354, 35.592508032],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 7,
+                name: 'Upper Mississippi Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-91.719515314, 42.83426983],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 8,
+                name: 'Lower Mississippi Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-91.53734907020255, 33.54103624020799],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 9,
+                name: 'Souris-Red-Rainy Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-97.42064729352984, 49.226235790304884],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 9,
+                name: 'Souris-Red-Rainy Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-114.13930954636578, 49.99332854905629],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 10,
+                name: 'Missouri Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-102.861312507, 43.744301875],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 11,
+                name: 'Arkansas-White-Red Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-98.437540298, 36.094387703],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 12,
+                name: 'Texas-Gulf Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-97.80995183001559, 31.586608173572984],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 13,
+                name: 'Rio Grande Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-105.85927750623031, 31.923558206414327],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 14,
+                name: 'Upper Colorado Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-109.022990163, 39.165107464],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 15,
+                name: 'Lower Colorado Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-111.914388969, 33.995973016],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 16,
+                name: 'Great Basin Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-115.717018816, 40.374248643],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 17,
+                name: 'Pacific Northwest Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-118.058405599, 46.028693029],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 18,
+                name: 'California Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-119.772122181, 37.427876934],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 19,
+                name: 'Alaska Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-150.511130716, 63.757185864],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 20,
+                name: 'Hawaii Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-156.58913094, 20.427874336],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 21,
+                name: 'Caribbean Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-66.235535985, 18.194997215],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                id: 22,
+                name: 'South Pacific Region',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [24.954304164, 3.209606223],
+            },
+        },
+    ],
+};


### PR DESCRIPTION
- Labels for regions should now draw 1 per polygon
- Removed HuC02 Boundaries without mainstems: Alaska, Hawaii, South Pacific, Caribbean 
- Added text halo for labels

To Test:
1. Label should draw close to center of polygon, some have been moved for greater legibility
2. Label should show for correct region in correct location
    a. Use existing implementation for reference: https://explorer.geoconnex.us/
3. Alaska, Hawaii, South Pacific, Caribbean HUC02 Boundaries should not render
4. Hover labels for mainstems should not show when HUC02 labels are visible
    
