### PR TITLE
Fix: remove redundant storage of datasets

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,7 +7,6 @@ import { MAP_ID as MAIN_MAP_ID } from '@/app/features/MainMap/config';
 import { SidePanel } from '@/app/features/SidePanel';
 import Table from '@/app/features/Table';
 import { MapTools } from '@/app/features/MapTools';
-import { useLayoutEffect } from 'react';
 import { setShowSidePanel } from '@/lib/state/main/slice';
 import IconButton from '@/app/components/common/IconButton';
 import HamburgerIcon from '@/app/assets/icons/Hamburger';
@@ -25,12 +24,6 @@ export const App: React.FC<Props> = (props) => {
     );
 
     const dispatch: AppDispatch = useDispatch();
-
-    useLayoutEffect(() => {
-        if (window.innerWidth > 1280) {
-            dispatch(setShowSidePanel(true));
-        }
-    }, []);
 
     const handleSidePanelControlClick = () => {
         dispatch(setShowSidePanel(true));

--- a/src/app/components/common/MultiSelect.tsx
+++ b/src/app/components/common/MultiSelect.tsx
@@ -55,7 +55,6 @@ const MultiSelect: React.FC<Props> = (props) => {
                                 className="cursor-pointer select-none relative py-2 pl-3 pr-9"
                                 role="option"
                                 aria-selected={selectedOptions?.includes(type)}
-                                onClick={() => handleOptionClick(type)}
                             >
                                 <div className="flex items-center">
                                     <input

--- a/src/app/components/common/Typography.tsx
+++ b/src/app/components/common/Typography.tsx
@@ -42,7 +42,12 @@ const sizes: Record<Variant, string> = {
     small: 'text-sm sm:text-xs',
 };
 
-export const Typography = ({ variant, children, className, as }: Props) => {
+export const Typography = ({
+    variant,
+    children,
+    className = '',
+    as,
+}: Props) => {
     const sizeClasses = sizes[variant];
     const Tag = as || tags[variant];
 

--- a/src/app/features/MainMap/index.tsx
+++ b/src/app/features/MainMap/index.tsx
@@ -31,6 +31,7 @@ import {
 import { extractLatLng } from '@/lib/state/utils';
 import {
     fetchDatasets,
+    getDatasets,
     reset,
     setLayerVisibility,
     setSelectedData,
@@ -56,12 +57,13 @@ export const MainMap: React.FC<Props> = (props) => {
 
     const {
         searchResultIds,
-        filteredDatasets,
         visibleLayers,
         hoverId,
         selectedMainstemId,
         selectedMainstemBBOX,
     } = useSelector((state: RootState) => state.main);
+
+    const datasets = useSelector(getDatasets);
 
     const [reloadFlag, setReloadFlag] = useState(0);
 
@@ -412,13 +414,13 @@ export const MainMap: React.FC<Props> = (props) => {
     }, [searchResultIds, selectedMainstemId, hoverId]);
 
     useEffect(() => {
-        if (!map || !filteredDatasets) {
+        if (!map || !datasets) {
             return;
         }
 
         const source = map.getSource(SourceId.AssociatedData) as GeoJSONSource;
         if (source) {
-            source.setData(filteredDatasets);
+            source.setData(datasets);
             const spiderfySource = map.getSource(
                 SourceId.Spiderify
             ) as GeoJSONSource;
@@ -436,7 +438,7 @@ export const MainMap: React.FC<Props> = (props) => {
                             ...feature,
                             properties: {
                                 ...feature.properties,
-                                isNotFiltered: filteredDatasets.features.some(
+                                isNotFiltered: datasets.features.some(
                                     (dataSetFeature) =>
                                         dataSetFeature.properties.url ===
                                         feature.properties.url
@@ -451,7 +453,7 @@ export const MainMap: React.FC<Props> = (props) => {
                 spiderfySource.setData(newData);
             }
         }
-    }, [filteredDatasets]);
+    }, [datasets]);
 
     useEffect(() => {
         if (!map) {

--- a/src/app/features/SidePanel/CSVDownload.tsx
+++ b/src/app/features/SidePanel/CSVDownload.tsx
@@ -1,18 +1,18 @@
 import Button from '@/app/components/common/Button';
 import { convertGeoJSONToCSV } from '@/app/utils/csv';
-import { RootState } from '@/lib/state/store';
+import { getDatasets } from '@/lib/state/main/slice';
 import { useSelector } from 'react-redux';
 
 export const CSVDownload: React.FC = () => {
-    const { filteredDatasets } = useSelector((state: RootState) => state.main);
+    const datasets = useSelector(getDatasets);
 
     return (
         <>
-            {filteredDatasets.features.length > 0 && (
+            {datasets.features.length > 0 && (
                 <div id="csvButton">
                     <Button
                         title="Download filtered datasets as CSV"
-                        onClick={() => convertGeoJSONToCSV(filteredDatasets)}
+                        onClick={() => convertGeoJSONToCSV(datasets)}
                     >
                         <span>Download CSV</span>
                     </Button>

--- a/src/app/features/SidePanel/Search.tsx
+++ b/src/app/features/SidePanel/Search.tsx
@@ -7,6 +7,7 @@ import { AppDispatch } from '@/lib/state/store';
 import {
     fetchDatasets,
     setDatasets,
+    setFilteredDatasets,
     setHoverId,
     setSearchResultIds,
     setSelectedMainstemId,
@@ -61,6 +62,7 @@ const SearchComponent: React.FC = () => {
                     defaultGeoJson as FeatureCollection<Geometry, Dataset>
                 )
             );
+            dispatch(setFilteredDatasets(null));
         }
     };
 

--- a/src/app/features/Table.tsx
+++ b/src/app/features/Table.tsx
@@ -1,11 +1,12 @@
+import { getDatasets } from '@/lib/state/main/slice';
 import { RootState } from '@/lib/state/store';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
 const Table: React.FC = () => {
-    const { filteredDatasets, selectedData } = useSelector(
-        (state: RootState) => state.main
-    );
+    const { selectedData } = useSelector((state: RootState) => state.main);
+
+    const datasets = useSelector(getDatasets);
 
     // TODO: ensure property order and call getHeaderValue
     return (
@@ -42,7 +43,7 @@ const Table: React.FC = () => {
                     </tr>
                 </thead>
                 <tbody>
-                    {filteredDatasets.features.map((feature, index) => (
+                    {datasets.features.map((feature, index) => (
                         <tr
                             key={index}
                             className={`${

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,34 +1,34 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import './globals.css';
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+    variable: '--font-geist-sans',
+    subsets: ['latin'],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+    variable: '--font-geist-mono',
+    subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
-  title: "explorer.geoconnex.us",
-  description: "Mainstem Exploration App",
+    title: 'explorer.geoconnex.us',
+    description: 'Mainstem Exploration App',
 };
 
 export default function RootLayout({
-  children,
+    children,
 }: Readonly<{
-  children: React.ReactNode;
+    children: React.ReactNode;
 }>) {
-  return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
-    </html>
-  );
+    return (
+        <html lang="en">
+            <body
+                className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+            >
+                {children}
+            </body>
+        </html>
+    );
 }

--- a/src/lib/state/main/__tests__/slice.test.ts
+++ b/src/lib/state/main/__tests__/slice.test.ts
@@ -4,7 +4,6 @@ import mainReducer, {
     setSelectedMainstemId,
     setHoverId,
     setDatasets,
-    setFilteredDatasets,
     setLayerVisibility,
     setSelectedData,
     setFilter,
@@ -51,17 +50,6 @@ describe('mainSlice', () => {
         store.dispatch(setDatasets(datasets));
         const state = store.getState().main;
         expect(state.datasets).toEqual(datasets);
-        expect(state.filteredDatasets).toEqual(datasets);
-    });
-
-    test('should handle setFilteredDatasets', () => {
-        const filteredDatasets: FeatureCollection<Geometry, Dataset> = {
-            type: 'FeatureCollection',
-            features: [],
-        };
-        store.dispatch(setFilteredDatasets(filteredDatasets));
-        const state = store.getState().main;
-        expect(state.filteredDatasets).toEqual(filteredDatasets);
     });
 
     test('should handle setLayerVisibility', () => {

--- a/src/lib/state/main/slice.ts
+++ b/src/lib/state/main/slice.ts
@@ -11,6 +11,7 @@ import { Dataset, MainstemData } from '@/app/types';
 import { LngLatBoundsLike } from 'mapbox-gl';
 import * as turf from '@turf/turf';
 import { defaultGeoJson } from '@/lib/state/consts';
+import { RootState } from '@/lib/state/store';
 
 export type Summary = {
     id: number;
@@ -34,7 +35,7 @@ type InitialState = {
     status: string;
     error: string | null;
     datasets: FeatureCollection<Geometry, Dataset>;
-    filteredDatasets: FeatureCollection<Geometry, Dataset>;
+    filteredDatasets: FeatureCollection<Geometry, Dataset> | null;
     view: 'map' | 'table';
     visibleLayers: {
         [LayerId.MajorRivers]: boolean;
@@ -70,7 +71,7 @@ const initialState: InitialState = {
     status: 'idle', // Additional state to track loading status
     error: null,
     datasets: defaultGeoJson as FeatureCollection<Geometry, Dataset>,
-    filteredDatasets: defaultGeoJson as FeatureCollection<Geometry, Dataset>,
+    filteredDatasets: null,
     view: 'map',
     visibleLayers: {
         [LayerId.MajorRivers]: true,
@@ -107,6 +108,8 @@ export const fetchDatasets = createAsyncThunk<
     return data;
 });
 
+export const getDatasets = (state: RootState) =>
+    state.main.filteredDatasets ?? state.main.datasets;
 
 export const mainSlice = createSlice({
     name: 'main',
@@ -135,7 +138,6 @@ export const mainSlice = createSlice({
             action: PayloadAction<InitialState['datasets']>
         ) => {
             state.datasets = action.payload;
-            state.filteredDatasets = action.payload;
         },
         setFilteredDatasets: (
             state,
@@ -208,10 +210,15 @@ export const mainSlice = createSlice({
                 return isVariableSelected && isStartDateValid && isEndDateValid;
             });
 
-            state.filteredDatasets = {
-                type: 'FeatureCollection',
-                features: features,
-            };
+            // If features are not filtered, dont store
+            if (state.datasets.features.length !== features.length) {
+                state.filteredDatasets = {
+                    type: 'FeatureCollection',
+                    features: features,
+                };
+            } else {
+                state.filteredDatasets = null;
+            }
         },
         setHoverId: (state, action: PayloadAction<InitialState['hoverId']>) => {
             state.hoverId = action.payload;
@@ -232,10 +239,7 @@ export const mainSlice = createSlice({
                 Geometry,
                 Dataset
             >;
-            state.filteredDatasets = defaultGeoJson as FeatureCollection<
-                Geometry,
-                Dataset
-            >;
+            state.filteredDatasets = null;
             state.selectedSummary = null;
         },
     },
@@ -273,7 +277,6 @@ export const mainSlice = createSlice({
                     // Transform datasets into a new feature collection
                     const datasets = transformDatasets(action.payload);
                     state.datasets = datasets;
-                    state.filteredDatasets = datasets;
                 }
                 return;
             })

--- a/src/lib/state/main/slice.ts
+++ b/src/lib/state/main/slice.ts
@@ -65,7 +65,7 @@ type InitialState = {
 };
 
 const initialState: InitialState = {
-    showSidePanel: false,
+    showSidePanel: true,
     showHelp: false,
     showResults: false,
     selectedMainstemId: null,

--- a/src/lib/state/main/slice.ts
+++ b/src/lib/state/main/slice.ts
@@ -41,7 +41,6 @@ type InitialState = {
     status: string;
     error: string | null;
     datasets: FeatureCollection<Geometry, Dataset>;
-    filteredDatasets: FeatureCollection<Geometry, Dataset> | null;
     view: 'map' | 'table';
     visibleLayers: {
         [LayerId.MajorRivers]: boolean;
@@ -78,7 +77,6 @@ const initialState: InitialState = {
     status: 'idle', // Additional state to track loading status
     error: null,
     datasets: defaultGeoJson as FeatureCollection<Geometry, Dataset>,
-    filteredDatasets: null,
     view: 'map',
     visibleLayers: {
         [LayerId.MajorRivers]: true,
@@ -120,7 +118,7 @@ const selectFilter = (state: RootState) => state.main.filter;
 // Memoized selector to prevent false rerender requests
 export const getDatasets = createSelector(
     [selectDatasets, selectFilter],
-    (datasets, filter) => {
+    (datasets, filter): FeatureCollection<Geometry, Dataset> => {
         if (
             !filter.selectedVariables &&
             !filter.startTemporalCoverage &&
@@ -199,12 +197,6 @@ export const mainSlice = createSlice({
         ) => {
             state.datasets = action.payload;
         },
-        setFilteredDatasets: (
-            state,
-            action: PayloadAction<InitialState['filteredDatasets']>
-        ) => {
-            state.filteredDatasets = action.payload;
-        },
         setSelectedMainstemId: (
             state,
             action: PayloadAction<InitialState['selectedMainstemId']>
@@ -257,7 +249,6 @@ export const mainSlice = createSlice({
                 Geometry,
                 Dataset
             >;
-            state.filteredDatasets = null;
             state.selectedSummary = null;
         },
     },
@@ -295,7 +286,6 @@ export const mainSlice = createSlice({
                     // Transform datasets into a new feature collection
                     const datasets = transformDatasets(action.payload);
                     state.datasets = datasets;
-                    state.filteredDatasets = datasets;
                     state.showResults = false;
                 }
                 return;
@@ -315,7 +305,6 @@ export const {
     setSelectedMainstemId,
     setHoverId,
     setDatasets,
-    setFilteredDatasets,
     setLayerVisibility,
     setSelectedData,
     setFilter,


### PR DESCRIPTION
Removed a redundant global state variable

To Test:
1. Search for a mainstem
2. Select a mainstem (from list or map)
3. Apply filters
    
Result:
Data is filtered as expected both in clusters and in table