### PR TITLE
Minor title / accessible change for icons

### DIFF
--- a/src/app/assets/icons/Controls.tsx
+++ b/src/app/assets/icons/Controls.tsx
@@ -9,7 +9,7 @@ const ControlsIcon: React.FC = () => {
             role="img"
             aria-labelledby="icon-title-controls icon-desc-controls"
         >
-            <title id="icon-title-controls">Controls Icon</title>
+            <title id="icon-title-controls">Map Control Menu</title>
             <desc id="icon-desc-controls">
                 A slider icon used to represent map settings
             </desc>

--- a/src/app/assets/icons/Layer.tsx
+++ b/src/app/assets/icons/Layer.tsx
@@ -9,7 +9,7 @@ const LayerIcon: React.FC = () => {
             role="img"
             aria-labelledby="icon-title-layer icon-desc-layer"
         >
-            <title id="icon-title-layer">Layer Icon</title>
+            <title id="icon-title-layer">Map Layer Settings</title>
             <desc id="icon-desc-layer">
                 This icon is used in a button to show layer visibility toggles
             </desc>

--- a/src/app/assets/icons/Legend.tsx
+++ b/src/app/assets/icons/Legend.tsx
@@ -9,7 +9,7 @@ const LegendIcon: React.FC = () => {
             role="img"
             aria-labelledby="icon-title-legend icon-desc-legend"
         >
-            <title id="icon-title-legend">Legend Icon</title>
+            <title id="icon-title-legend">Legend Reference</title>
             <desc id="icon-desc-legend">
                 This icon is used in a button to show the map legend
             </desc>


### PR DESCRIPTION
Minor change; The title for an icon doesn't need to say it is an icon but rather should declare the purpose of the element. i.e. for instance if you go to gmail with a screen reader and read the gmail icon, it won't tell you that its an icon but rather just tells what the icon's purpose is. It is the reponsibility of the screen reader to speak the element type if that is enabled. (i.e. in Orca you can tick a setting to toggle speaking the element type or just speak what is directly on screen)

Since title is shown on hover as well, a non-visually impaired user doesn't need to know it is an icon.
