### PR TITLE
Fix: CSV records, CSV name, variable search behavior, results messaging

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import Table from '@/app/features/Table';
 import { MapTools } from '@/app/features/MapTools';
 import {
     fetchDatasets,
+    getFilteredDatasetsInBounds,
     setLoading,
     setShowSidePanel,
 } from '@/lib/state/main/slice';
@@ -43,6 +44,10 @@ export const App: React.FC<Props> = (props) => {
     const dispatch: AppDispatch = useDispatch();
 
     const { map } = useMap(MAIN_MAP_ID);
+
+    const datasets = useSelector((state: RootState) =>
+        getFilteredDatasetsInBounds(state, map)
+    );
 
     useEffect(() => {
         // Ensure map is loaded
@@ -97,9 +102,9 @@ export const App: React.FC<Props> = (props) => {
                 <div
                     id="side-panel"
                     className={`
-                    w-full lg:w-[45vw] xl:w-[30vw] 2xl:w-[20vw] 
+                     w-full lg:w-[45vw] xl:w-[30vw] 2xl:w-[20vw] 
                      min-w-[300px] sm:min-w-[400px]
-                    md:max-w-[400px]
+                     md:max-w-[400px]
                      flex overflow-hidden bg-primary
                      m-2 lg:m-0
                      border lg:border-l-0 lg:border-t-0 lg:border-b-0
@@ -107,7 +112,7 @@ export const App: React.FC<Props> = (props) => {
                      shadow-lg
                      ${showSidePanel ? 'block' : 'hidden'}`}
                 >
-                    <SidePanel />
+                    <SidePanel datasets={datasets} />
                 </div>
                 <div id="tools" className={`fixed top-3 right-2`}>
                     {view === 'map' && <MapTools />}
@@ -130,7 +135,7 @@ export const App: React.FC<Props> = (props) => {
                     {view === 'table' && (
                         <>
                             <LoadingBar />
-                            <Table />
+                            <Table datasets={datasets} />
                         </>
                     )}
                 </div>

--- a/src/app/features/HelpModal.tsx
+++ b/src/app/features/HelpModal.tsx
@@ -137,7 +137,7 @@ export const HelpModal: React.FC = () => {
                 <li className="list-disc break-words whitespace-normal">
                     <Typography variant="body-small">
                         View datasets either <strong>on the map</strong> or in
-                        the <strong>Table tab</strong>.
+                        the <strong>Table view</strong>.
                     </Typography>
                 </li>
             </ul>

--- a/src/app/features/MainMap/config.tsx
+++ b/src/app/features/MainMap/config.tsx
@@ -926,7 +926,7 @@ export const getLayerClickFunction = (
  *
  * LayerDefinition Type:
  * - id: string - The identifier for the layer or sublayer.
- * - controllable: boolean - Whether the layer is controllable by the user.
+ * - controllable: boolean - Whether the layers visibility can be toggled by the user.
  * - legend: boolean - Whether the layer should be displayed in the legend.
  * - config: LayerSpecification | null - The configuration object for the layer or sublayer.
  * - hoverFunction?: CustomListenerFunction - Optional function to handle hover events.

--- a/src/app/features/MainMap/config.tsx
+++ b/src/app/features/MainMap/config.tsx
@@ -764,6 +764,7 @@ export const getLayerCustomHoverExitFunction = (
             case SubLayerId.AssociatedDataClusters:
                 return () => {
                     hoverOnCluster = false;
+                    map.getCanvas().style.cursor = '';
                 };
             case SubLayerId.MainstemsSmall:
                 return () => {
@@ -827,6 +828,11 @@ export const getLayerMouseMoveFunction = (
 ): CustomListenerFunction => {
     return (map: Map, hoverPopup: Popup, persistentPopup: Popup) => {
         switch (id) {
+            case SubLayerId.AssociatedDataClusters:
+                return () => {
+                    hoverOnCluster = true;
+                    map.getCanvas().style.cursor = 'pointer';
+                };
             case SubLayerId.HUC2BoundaryFill:
                 return (e) => {
                     const zoom = map.getZoom();
@@ -1059,6 +1065,9 @@ export const layerDefinitions: MainLayerDefinition[] = [
                 legend: false,
                 config: getLayerConfig(SubLayerId.AssociatedDataClusters),
                 clickFunction: getLayerClickFunction(
+                    SubLayerId.AssociatedDataClusters
+                ),
+                mouseMoveFunction: getLayerMouseMoveFunction(
                     SubLayerId.AssociatedDataClusters
                 ),
                 hoverFunction: getLayerHoverFunction(

--- a/src/app/features/MapTools/index.tsx
+++ b/src/app/features/MapTools/index.tsx
@@ -144,7 +144,7 @@ export const MapTools: React.FC = () => {
                                     </span>
                                     <span className="flex">
                                         <CircleIcon color="#91bfdb" />
-                                        &lt;= 50
+                                        &lt; 50
                                     </span>
                                     <span className="flex">
                                         <CircleIcon color="#ffffbf" />
@@ -152,7 +152,7 @@ export const MapTools: React.FC = () => {
                                     </span>
                                     <span className="flex">
                                         <CircleIcon color="#fc8d59" />
-                                        &gt; 200
+                                        &gt;= 200
                                     </span>
                                 </div>
                             </>

--- a/src/app/features/SidePanel/CSVDownload.tsx
+++ b/src/app/features/SidePanel/CSVDownload.tsx
@@ -1,10 +1,11 @@
 import Button from '@/app/components/common/Button';
-import { Dataset } from '@/app/types';
+import { Dataset, MainstemData } from '@/app/types';
 import { convertGeoJSONToCSV } from '@/app/utils/csv';
 import { FeatureCollection, Point } from 'geojson';
 
 type Props = {
     datasets: FeatureCollection<Point, Dataset>;
+    selectedMainstem: MainstemData;
 };
 
 /**
@@ -12,11 +13,16 @@ type Props = {
  *
  * Props:
  * - datasets: FeatureCollection<Point, Dataset> - Datasets to convert from feature collection to CSV file.
+ * - selectedMainstem: MainstemData - Properties of the current selected mainstem for determining the CSV file name.
  *
  * @component
  */
 export const CSVDownload: React.FC<Props> = (props) => {
-    const { datasets } = props;
+    const { datasets, selectedMainstem } = props;
+
+    // Exclude `:`, invalid sheet and file name char
+    const fileName =
+        selectedMainstem.name_at_outlet || 'URI ' + selectedMainstem.id;
 
     return (
         <>
@@ -24,7 +30,7 @@ export const CSVDownload: React.FC<Props> = (props) => {
                 <div id="csvButton">
                     <Button
                         title="Download filtered datasets as CSV"
-                        onClick={() => convertGeoJSONToCSV(datasets)}
+                        onClick={() => convertGeoJSONToCSV(datasets, fileName)}
                     >
                         <span>Download CSV</span>
                     </Button>

--- a/src/app/features/SidePanel/Filters/Variables.tsx
+++ b/src/app/features/SidePanel/Filters/Variables.tsx
@@ -73,6 +73,7 @@ export const Variables: React.FC<Props> = (props) => {
                 handleOptionClick={handleTypeOptionClick}
                 searchable
                 selectAll
+                strictSearch
                 limit={100}
                 handleSelectAll={handleSelectAll}
             />

--- a/src/app/features/SidePanel/index.tsx
+++ b/src/app/features/SidePanel/index.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch, RootState } from '@/lib/state/store';
 import {
-    getFilteredDatasets,
     getDatasetsLength,
     getSelectedSummary,
     setSearchResultIds,
@@ -18,12 +17,17 @@ import HelpIcon from '@/app/assets/icons/Help';
 import { Typography } from '@/app/components/common/Typography';
 import { useEffect, useState } from 'react';
 import { Results } from '@/app/features/SidePanel/Results';
-import { MainstemData } from '@/app/types';
+import { Dataset, MainstemData } from '@/app/types';
 import { ComplexSummary } from '@/app/features/SidePanel/Summary/Complex';
 import { useMap } from '@/app/contexts/MapContexts';
 import { MAP_ID as MAIN_MAP_ID } from '@/app/features/MainMap/config';
 import Button from '@/app/components/common/Button';
 import Image from 'next/image';
+import { FeatureCollection, Point } from 'geojson';
+
+type Props = {
+    datasets: FeatureCollection<Point, Dataset>;
+};
 
 /**
  * This component manages the state and display of search results, filter component, and selected
@@ -31,7 +35,9 @@ import Image from 'next/image';
  *
  *  @component
  */
-const SidePanel: React.FC = () => {
+const SidePanel: React.FC<Props> = (props) => {
+    const { datasets } = props;
+
     const [results, setResults] = useState<MainstemData[]>([]);
 
     const { map } = useMap(MAIN_MAP_ID);
@@ -42,8 +48,6 @@ const SidePanel: React.FC = () => {
 
     // Total length of unfiltered features from datasets feature collection
     const datasetsLength = useSelector(getDatasetsLength);
-    // Filtered datasets within map bounds
-    const datasets = useSelector(getFilteredDatasets);
 
     // Summary information for filtered datasets within map bounds
     const selectedSummary = useSelector((state: RootState) =>
@@ -149,12 +153,15 @@ const SidePanel: React.FC = () => {
                         <Results results={results} />
                     </Collapsible>
                 </div>
-                {datasetsLength > 0 && (
+                {selectedMainstem && datasetsLength > 0 && (
                     <Collapsible title="Filters">
                         <div className="p-4">
                             <Filters />
                             <div className="mt-5 mb-2">
-                                <CSVDownload datasets={datasets} />
+                                <CSVDownload
+                                    datasets={datasets}
+                                    selectedMainstem={selectedMainstem}
+                                />
                             </div>
                         </div>
                     </Collapsible>

--- a/src/app/features/SidePanel/index.tsx
+++ b/src/app/features/SidePanel/index.tsx
@@ -150,6 +150,26 @@ const SidePanel: React.FC<Props> = (props) => {
                 {/* Results makes async call, ensure mounting */}
                 <div className={`${results.length > 0 ? 'block' : 'hidden'}`}>
                     <Collapsible title="Results" open={showResults}>
+                        <div className="py-2 border-b border-gray-300">
+                            {results.length && (
+                                <Typography
+                                    variant="body-small"
+                                    className="text-center"
+                                >
+                                    Results sorted by{' '}
+                                    <strong>Outlet Drainage Area</strong>.
+                                    {results.length === 500 && (
+                                        <>
+                                            <br />
+                                            Showing top <strong>
+                                                500
+                                            </strong>{' '}
+                                            results.
+                                        </>
+                                    )}
+                                </Typography>
+                            )}
+                        </div>
                         <Results results={results} />
                     </Collapsible>
                 </div>

--- a/src/app/features/Table/Pagination.tsx
+++ b/src/app/features/Table/Pagination.tsx
@@ -29,7 +29,7 @@ const Pagination: React.FC<Props> = (props) => {
         <div className="min-h-[118px] lg:min-h-[unset] flex flex-col lg:flex-row items-center gap-4 justify-center py-2 ml-6 lg:ml-0">
             <div className="flex gap-2">
                 <button
-                    className="border rounded p-1 text-lg text-black disabled:opacity-70"
+                    className="border rounded p-1 text-lg text-black text-md disabled:opacity-70"
                     onClick={() => paginationFunctions.firstPage()}
                     disabled={!paginationFunctions.getCanPreviousPage()}
                     title="Go to first page"
@@ -37,7 +37,7 @@ const Pagination: React.FC<Props> = (props) => {
                     {' ⏮ '}
                 </button>
                 <button
-                    className="border rounded p-1 text-black disabled:opacity-70"
+                    className="border rounded p-1 text-black text-md disabled:opacity-70"
                     onClick={() => paginationFunctions.previousPage()}
                     disabled={!paginationFunctions.getCanPreviousPage()}
                     title="Go to previous page"
@@ -46,7 +46,7 @@ const Pagination: React.FC<Props> = (props) => {
                 </button>
                 <button
                     data-testid="next-button"
-                    className="border rounded p-1 text-black disabled:opacity-70"
+                    className="border rounded p-1 text-black text-md disabled:opacity-70"
                     onClick={() => paginationFunctions.nextPage()}
                     disabled={!paginationFunctions.getCanNextPage()}
                     title="Go to next page"
@@ -54,7 +54,7 @@ const Pagination: React.FC<Props> = (props) => {
                     {' ▶ '}
                 </button>
                 <button
-                    className="border rounded p-1 text-lg text-black disabled:opacity-70"
+                    className="border rounded p-1 text-lg text-black text-md disabled:opacity-70"
                     onClick={() => paginationFunctions.lastPage()}
                     disabled={!paginationFunctions.getCanNextPage()}
                     title="Go to last page"

--- a/src/app/features/Table/Pagination.tsx
+++ b/src/app/features/Table/Pagination.tsx
@@ -29,7 +29,7 @@ const Pagination: React.FC<Props> = (props) => {
         <div className="min-h-[118px] lg:min-h-[unset] flex flex-col lg:flex-row items-center gap-4 justify-center py-2 ml-6 lg:ml-0">
             <div className="flex gap-2">
                 <button
-                    className="border rounded p-1 text-lg text-black text-md disabled:opacity-70"
+                    className="border rounded p-1 text-lg text-black disabled:opacity-70"
                     onClick={() => paginationFunctions.firstPage()}
                     disabled={!paginationFunctions.getCanPreviousPage()}
                     title="Go to first page"
@@ -37,7 +37,7 @@ const Pagination: React.FC<Props> = (props) => {
                     {' ⏮ '}
                 </button>
                 <button
-                    className="border rounded p-1 text-black text-md disabled:opacity-70"
+                    className="border rounded p-1 text-black text-base disabled:opacity-70"
                     onClick={() => paginationFunctions.previousPage()}
                     disabled={!paginationFunctions.getCanPreviousPage()}
                     title="Go to previous page"
@@ -46,7 +46,7 @@ const Pagination: React.FC<Props> = (props) => {
                 </button>
                 <button
                     data-testid="next-button"
-                    className="border rounded p-1 text-black text-md disabled:opacity-70"
+                    className="border rounded p-1 text-black text-base disabled:opacity-70"
                     onClick={() => paginationFunctions.nextPage()}
                     disabled={!paginationFunctions.getCanNextPage()}
                     title="Go to next page"
@@ -54,7 +54,7 @@ const Pagination: React.FC<Props> = (props) => {
                     {' ▶ '}
                 </button>
                 <button
-                    className="border rounded p-1 text-lg text-black text-md disabled:opacity-70"
+                    className="border rounded p-1 text-lg text-black disabled:opacity-70"
                     onClick={() => paginationFunctions.lastPage()}
                     disabled={!paginationFunctions.getCanNextPage()}
                     title="Go to last page"

--- a/src/app/features/Table/__tests__/index.test.tsx
+++ b/src/app/features/Table/__tests__/index.test.tsx
@@ -37,8 +37,8 @@ const datasets: FeatureCollection<Point, Dataset> = {
 };
 
 const filter = {
-    selectedVariables: ['Variable 1'],
-    selectedTypes: ['Type 1'],
+    variables: ['Variable 1'],
+    types: ['Type 1'],
     startTemporalCoverage: '1969-01-01',
     endTemporalCoverage: '2030-01-01',
 };
@@ -54,7 +54,7 @@ describe('Table', () => {
     test('renders table headers correctly', () => {
         render(
             <Provider store={store}>
-                <Table />
+                <Table datasets={datasets} />
             </Provider>
         );
 
@@ -64,7 +64,7 @@ describe('Table', () => {
     test('renders table rows correctly', () => {
         render(
             <Provider store={store}>
-                <Table />
+                <Table datasets={datasets} />
             </Provider>
         );
 
@@ -74,7 +74,7 @@ describe('Table', () => {
     test('handles pagination correctly', () => {
         render(
             <Provider store={store}>
-                <Table />
+                <Table datasets={datasets} />
             </Provider>
         );
 

--- a/src/app/features/Table/index.tsx
+++ b/src/app/features/Table/index.tsx
@@ -12,12 +12,10 @@ import {
 import { Dataset } from '@/app/types';
 import Pagination from '@/app/features/Table/Pagination';
 import Table from '@/app/features/Table/Table';
-import { getFilteredDatasetsInBounds, setView } from '@/lib/state/main/slice';
-import { MAP_ID as MAIN_MAP_ID } from '@/app/features/MainMap/config';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '@/lib/state/store';
-import { useMap } from '@/app/contexts/MapContexts';
+import { setView } from '@/lib/state/main/slice';
+import { useDispatch } from 'react-redux';
 import CloseButton from '@/app/components/common/CloseButton';
+import { FeatureCollection, Point } from 'geojson';
 
 export enum HeaderKey {
     SiteName = 'siteName',
@@ -62,12 +60,12 @@ export const getHeaderTooltipText = (headerKey: HeaderKey) => {
     }
 };
 
-const TableWrapper: React.FC = () => {
-    const { map } = useMap(MAIN_MAP_ID);
+type Props = {
+    datasets: FeatureCollection<Point, Dataset>;
+};
 
-    const datasets = useSelector((state: RootState) =>
-        getFilteredDatasetsInBounds(state, map)
-    );
+const TableWrapper: React.FC<Props> = (props) => {
+    const { datasets } = props;
 
     const dispatch = useDispatch();
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,12 +1,13 @@
 /**
- * Primary mainstem data type.
- * When requesting from /items contains just below.
- * When requesting from /items/[uri] contains an additional optional
- * key 'datasets' containing 0 -> 100,000 objects containing the properties
- * in type Datasets.
+ * Primary mainstem data type. Excluding datasets property.
+ *
  *
  * @interface
  */
+// When requesting from /items contains just below.
+// When requesting from /items/[uri] contains an additional optional
+// key 'datasets' containing 0 -> 100,000 objects containing the properties
+// in type Datasets.
 export interface MainstemData {
     downstream_mainstem_id: string;
     encompassing_mainstem_basins: string[];
@@ -33,7 +34,7 @@ export interface MainstemData {
 }
 
 /**
- * Dataset type containing properties for datasets.
+ * Type containing properties of datasets.
  *
  * @type
  */

--- a/src/app/utils/csv.ts
+++ b/src/app/utils/csv.ts
@@ -6,9 +6,13 @@ import { Dataset } from '@/app/types';
  * Converts a GeoJSON FeatureCollection to a CSV file and triggers a download.
  *
  * @param geojson - The GeoJSON FeatureCollection containing Point features with Dataset properties.
+ * @param fileName - Name of CSV file
+ *
+ *@function
  */
 export const convertGeoJSONToCSV = (
-    geojson: FeatureCollection<Point, Dataset>
+    geojson: FeatureCollection<Point, Dataset>,
+    fileName: string
 ) => {
     const datasets = geojson.features.map((feature) => feature.properties);
 
@@ -25,7 +29,7 @@ export const convertGeoJSONToCSV = (
     // Create a link element
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
-    link.download = 'datasets.csv';
+    link.download = fileName + '.csv';
 
     // Append the link to the body
     document.body.appendChild(link);


### PR DESCRIPTION
### Description:
Addressing some minor bugs and behaviors:

-  CSV records need to match what is shown in the table, reflecting the map extent and applied filters. 
- Update for better file names. 
- Certain records in the variables filter were undiscoverable, adjusted the logic to allow capitals in the search. 
- Added a message in the results tab indicating what the sort order is, added additional message when the mainstems search hits the record count limit.

### To Test:
1. CSV Records
    a. With mainstem in full view, download csv
    b. Row count should match total datasets in mainstem summary and table count
    c. Zoom into portion of mainstem
    d. Row count should match visible datasets in mainstem summary and table count
    e. Apply filters
    f. Row count should match visible datasets in mainstem summary and table count
2. CSV File name
    a. Select named mainstem, download csv
    b. File name should match name at outlet
    c. Select unnamed mainstem, download csv
    d. File name should match `URI [id]`
3. Variables search
    a. In the variables dropdown, search with capital letters
    b. Results matching the capitalization should show at the top of the list, followed by soft matching on just the letters
    EX: query as `pH`, option `pH` shows at the top of the list with other options containing the substring `ph` following
4. Results messaging
   a. Search for mainstems using text search, results box contains message: `Results sorted by Outlet Drainage Area.`
   b. Search for a very general term like 'river'
   c. Results contains additional message: `Showing top 500 results.`